### PR TITLE
A-Assertions: add Java assertions to document assumptions

### DIFF
--- a/src/main/java/mang/Deadline.java
+++ b/src/main/java/mang/Deadline.java
@@ -17,6 +17,8 @@ public class Deadline extends Task {
      */
     public Deadline(String description, LocalDate by) {
         super(description);
+        // The due date must not be null
+        assert by != null : "Deadline date must not be null";
         this.by = by;
     }
 

--- a/src/main/java/mang/Event.java
+++ b/src/main/java/mang/Event.java
@@ -17,6 +17,9 @@ public class Event extends Task {
     @SuppressWarnings("checkstyle:Regexp")
     public Event(String description, String from, String to) {
         super(description);
+        // The start and end times must not be null
+        assert from != null : "Event start time must not be null";
+        assert to != null : "Event end time must not be null";
         this.from = from;
         this.to = to;
     }

--- a/src/main/java/mang/TaskList.java
+++ b/src/main/java/mang/TaskList.java
@@ -66,8 +66,13 @@ public class TaskList {
      * @throws IllegalArgumentException If the index is out of bounds.
      */
     public Task mark(int oneBasedIndex) {
+        // The index must be >= 1 (document important assumption)
+        assert oneBasedIndex > 0 : "Index must be > 0";
         int i = oneBasedIndex - 1;
         validateIndex(oneBasedIndex);
+
+        // The task at the index must not be null
+        assert tasks[i] != null : "Task at index must not be null";
         tasks[i].markDone();
         return tasks[i];
     }
@@ -80,8 +85,13 @@ public class TaskList {
      * @throws IllegalArgumentException If the index is out of bounds.
      */
     public Task unmark(int oneBasedIndex) {
+        // The index must be >= 1 (document important assumption)
+        assert oneBasedIndex > 0 : "Index must be > 0";
         int i = oneBasedIndex - 1;
         validateIndex(oneBasedIndex);
+
+        // The task at the index must not be null
+        assert tasks[i] != null : "Task at index must not be null";
         tasks[i].markUndone();
         return tasks[i];
     }


### PR DESCRIPTION
Add Java `assert` statements to document and verify important assumptions at runtime.
Assertions are enabled at runtime using the `-ea` option.
This PR is part of the A-Assertions increment.